### PR TITLE
Protect order detail page from unauthenticated access

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,7 +52,9 @@ function AppContent() {
   // Check for protected routes and redirect if not authenticated
   useEffect(() => {
     const protectedPaths = ['/orders', '/profile', '/favorites'];
-    const isProtectedPath = protectedPaths.some(path => location.pathname === path);
+    const isProtectedPath =
+      protectedPaths.some(path => location.pathname === path) ||
+      location.pathname.startsWith('/orders/');
     
     if (isProtectedPath && !isAuthenticated) {
       setIsAuthModalOpen(true);
@@ -138,7 +140,11 @@ function AppContent() {
         />
         <Route
           path="/orders/:orderId"
-          element={<OrderDetailPage />}
+          element={
+            <ProtectedRoute>
+              <OrderDetailPage />
+            </ProtectedRoute>
+          }
         />
         <Route
           path="/profile"


### PR DESCRIPTION
### Motivation
- Fix an auth-routing bug where `/orders/:orderId` could be opened without authentication, causing inconsistent behavior compared to the `/orders` list route. 
- Ensure the auth modal + redirect handling in `AppContent` treats nested order URLs as protected so unauthenticated users are prompted to sign in before viewing order details.

### Description
- Updated protected-path detection in `frontend/src/App.tsx` to treat nested order URLs as protected by adding `location.pathname.startsWith('/orders/')` to the check in the `useEffect` that opens the auth modal and redirects unauthenticated users. 
- Wrapped the `/orders/:orderId` route in `frontend/src/App.tsx` with the existing `ProtectedRoute` so the order detail page requires authentication like the orders list.

### Testing
- Ran `cd frontend && npm run build` and the production build completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b375d23bd4832f81cb5bb3715582ea)